### PR TITLE
Improved the login and forgot password pages

### DIFF
--- a/lib/screens/forgot_password.dart
+++ b/lib/screens/forgot_password.dart
@@ -71,7 +71,7 @@ class _ForgotPasswordState extends State<ForgotPassword> {
                             SizedBox(height: responsiveHeight(10.0)),
                             displayErrorMessage(),
                             SizedBox(height: responsiveHeight(65.0)),
-                            submitRequestButton(context),                           
+                            submitRequestButton(context),
                           ],
                         ),
                       ),
@@ -118,13 +118,13 @@ class _ForgotPasswordState extends State<ForgotPassword> {
           formKey.currentState.save();
           try {
             await context.read<AuthenticationService>().passwordReset(
-            email: emailController.text.trim(),
-            );
+                  email: emailController.text.trim(),
+                );
             customPopUp(context);
-          }catch (error) {
+          } catch (error) {
             setState(() {
               eMessage = error.message;
-            });    
+            });
           }
         }
       },
@@ -133,14 +133,12 @@ class _ForgotPasswordState extends State<ForgotPassword> {
 
   Widget displayErrorMessage() {
     if (eMessage != null) {
-      return Text(
-        eMessage,
-        style: TextStyle(
-          color: Colors.redAccent,
-          fontSize: responsiveWidth(9.0),
-          fontWeight: FontWeight.w500,
-        )
-      );
+      return Text(eMessage,
+          style: TextStyle(
+            color: Colors.redAccent,
+            fontSize: responsiveWidth(9.0),
+            fontWeight: FontWeight.w500,
+          ));
     } else {
       return Text('');
     }
@@ -162,29 +160,27 @@ class _ForgotPasswordState extends State<ForgotPassword> {
           backgroundColor: Theme.of(context).primaryColor,
           actions: [
             TextButton(
-              child: Text(
-                'Back to Submit Request',
-                style: TextStyle(color: Colors.white),
-              ),
-              onPressed: () {
-                Navigator.of(context).pushNamed(ForgotPassword.routeName);
-              },
-              style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all(Colors.green),
-              )
-            ),
+                child: Text(
+                  'Back to Submit Request',
+                  style: TextStyle(color: Colors.white),
+                ),
+                onPressed: () {
+                  Navigator.of(context).pushNamed(ForgotPassword.routeName);
+                },
+                style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all(Colors.green),
+                )),
             TextButton(
-              child: Text(
-                'Begin Sign in',
-                style: TextStyle(color: Colors.white),
-              ),
-              onPressed: () {
-                Navigator.of(context).pushNamed(SignInScreen.routeName);
-              },
-              style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all(Colors.green),
-              )
-            ),
+                child: Text(
+                  'Begin Sign in',
+                  style: TextStyle(color: Colors.white),
+                ),
+                onPressed: () {
+                  Navigator.of(context).pushNamed(SignInScreen.routeName);
+                },
+                style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all(Colors.green),
+                )),
           ],
         );
       },

--- a/lib/screens/forgot_password.dart
+++ b/lib/screens/forgot_password.dart
@@ -2,6 +2,7 @@ import 'package:email_validator/email_validator.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bikeapp/models/responsive_size.dart';
+import 'package:bikeapp/screens/sign_in_screen.dart';
 import 'package:bikeapp/services/authentication_service.dart';
 import 'package:bikeapp/styles/color_gradients.dart';
 import 'package:bikeapp/styles/cool_button.dart';
@@ -119,7 +120,7 @@ class _ForgotPasswordState extends State<ForgotPassword> {
             await context.read<AuthenticationService>().passwordReset(
             email: emailController.text.trim(),
             );
-            _showDialog(context);
+            customPopUp(context);
           }catch (error) {
             setState(() {
               eMessage = error.message;
@@ -145,8 +146,8 @@ class _ForgotPasswordState extends State<ForgotPassword> {
     }
   }
 
-  Future<void> _showDialog(BuildContext context) async {
-    return showDialog(
+  void customPopUp(BuildContext context) {
+    showDialog(
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
@@ -161,16 +162,29 @@ class _ForgotPasswordState extends State<ForgotPassword> {
           backgroundColor: Theme.of(context).primaryColor,
           actions: [
             TextButton(
-                child: Text(
-                  'OK',
-                  style: TextStyle(color: Colors.white),
-                ),
-                onPressed: () {
-                  Navigator.of(context).pop();
-                },
-                style: ButtonStyle(
-                  backgroundColor: MaterialStateProperty.all(Colors.green),
-                )),
+              child: Text(
+                'Back to Submit Request',
+                style: TextStyle(color: Colors.white),
+              ),
+              onPressed: () {
+                Navigator.of(context).pushNamed(ForgotPassword.routeName);
+              },
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all(Colors.green),
+              )
+            ),
+            TextButton(
+              child: Text(
+                'Begin Sign in',
+                style: TextStyle(color: Colors.white),
+              ),
+              onPressed: () {
+                Navigator.of(context).pushNamed(SignInScreen.routeName);
+              },
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all(Colors.green),
+              )
+            ),
           ],
         );
       },

--- a/lib/screens/forgot_password.dart
+++ b/lib/screens/forgot_password.dart
@@ -18,6 +18,13 @@ class _ForgotPasswordState extends State<ForgotPassword> {
   final TextEditingController emailController = TextEditingController();
   final formKey = GlobalKey<FormState>();
   String email;
+  String eMessage;
+
+  @override
+  void initState() {
+    eMessage = "";
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,10 +66,11 @@ class _ForgotPasswordState extends State<ForgotPassword> {
                         key: formKey,
                         child: Column(
                           children: [
-                            //emailTextField(emailController),
                             emailTextField(),
+                            SizedBox(height: responsiveHeight(10.0)),
+                            displayErrorMessage(),
                             SizedBox(height: responsiveHeight(65.0)),
-                            submitRequestButton(context, formKey),
+                            submitRequestButton(context),                           
                           ],
                         ),
                       ),
@@ -96,22 +104,45 @@ class _ForgotPasswordState extends State<ForgotPassword> {
     );
   }
 
-  Widget submitRequestButton(BuildContext context, formKey) {
+  Widget submitRequestButton(BuildContext context) {
     return CoolButton(
       title: 'Submit Request',
       textColor: Colors.white,
       filledColor: Colors.green,
-      onPressed: () {
+      onPressed: () async {
+        setState(() {
+          eMessage = "";
+        });
         if (formKey.currentState.validate()) {
           formKey.currentState.save();
-          context.read<AuthenticationService>().passwordReset(
-                email: emailController.text.trim(),
-              );
-          Navigator.of(context).pop();
+          try {
+            await context.read<AuthenticationService>().passwordReset(
+            email: emailController.text.trim(),
+            );
+            _showDialog(context);
+          }catch (error) {
+            setState(() {
+              eMessage = error.message;
+            });    
+          }
         }
-        _showDialog(context);
       },
     );
+  }
+
+  Widget displayErrorMessage() {
+    if (eMessage != null) {
+      return Text(
+        eMessage,
+        style: TextStyle(
+          color: Colors.redAccent,
+          fontSize: responsiveWidth(9.0),
+          fontWeight: FontWeight.w500,
+        )
+      );
+    } else {
+      return Text('');
+    }
   }
 
   Future<void> _showDialog(BuildContext context) async {

--- a/lib/screens/sign_in_screen.dart
+++ b/lib/screens/sign_in_screen.dart
@@ -18,7 +18,7 @@ class SignInScreen extends StatelessWidget {
           child: SizedBox(
             child: Container(
               padding: EdgeInsets.symmetric(
-                  vertical: responsiveHeight(35.0),
+                  vertical: responsiveHeight(25.0),
                   horizontal: responsiveWidth(15.0)),
               child: SingleChildScrollView(
                 child: Column(
@@ -41,7 +41,7 @@ class SignInScreen extends StatelessWidget {
                     ),
                     SizedBox(height: responsiveHeight(30.0)),
                     SignInForm(),
-                    SizedBox(height: responsiveHeight(52.0)),
+                    SizedBox(height: responsiveHeight(40.0)),
                     withoutAccount(context),
                   ],
                 ),

--- a/lib/services/authentication_service.dart
+++ b/lib/services/authentication_service.dart
@@ -1,21 +1,18 @@
 import 'package:firebase_auth/firebase_auth.dart';
+//import 'package:flutter/services.dart';
+
 // Followed along with video https://www.youtube.com/watch?v=oJ5Vrya3wCQ
 
 class AuthenticationService {
   final FirebaseAuth _firebaseAuth;
-
   AuthenticationService(this._firebaseAuth);
 
   Stream<User> get authStateChanges => _firebaseAuth.authStateChanges();
-
+ 
   Future<String> signIn({String email, String password}) async {
-    try {
-      await _firebaseAuth.signInWithEmailAndPassword(
-          email: email, password: password);
-      return "Signed in";
-    } on FirebaseAuthException catch (e) {
-      return e.message;
-    }
+    UserCredential result = await _firebaseAuth.signInWithEmailAndPassword(email: email, password: password);
+    User user = result.user;
+    return user.uid;
   }
 
   Future<String> createAccount({String email, String password}) async {

--- a/lib/services/authentication_service.dart
+++ b/lib/services/authentication_service.dart
@@ -8,9 +8,10 @@ class AuthenticationService {
   AuthenticationService(this._firebaseAuth);
 
   Stream<User> get authStateChanges => _firebaseAuth.authStateChanges();
- 
+
   Future<String> signIn({String email, String password}) async {
-    UserCredential result = await _firebaseAuth.signInWithEmailAndPassword(email: email, password: password);
+    UserCredential result = await _firebaseAuth.signInWithEmailAndPassword(
+        email: email, password: password);
     User user = result.user;
     return user.uid;
   }

--- a/lib/widgets/sign_in_form.dart
+++ b/lib/widgets/sign_in_form.dart
@@ -8,6 +8,7 @@ import 'package:bikeapp/styles/cool_button.dart';
 import 'package:bikeapp/styles/custom_input_decoration.dart';
 
 class SignInForm extends StatefulWidget {
+
   @override
   _SignInFormState createState() => _SignInFormState();
 }
@@ -18,6 +19,13 @@ class _SignInFormState extends State<SignInForm> {
   final TextEditingController passwordController = TextEditingController();
   String email;
   String password;
+  String eMessage;
+
+  @override
+  void initState() {
+    eMessage = "";
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +40,9 @@ class _SignInFormState extends State<SignInForm> {
             SizedBox(height: responsiveHeight(20.0)),
             forgotPasswordText(context),
             SizedBox(height: responsiveHeight(20.0)),
-            signInButton(context, formKey),
+            signInButton(context),
+            SizedBox(height: responsiveHeight(10.0)),
+            displayErrorMessage(),
           ],
         ),
       ),
@@ -45,13 +55,13 @@ class _SignInFormState extends State<SignInForm> {
       keyboardType: TextInputType.emailAddress,
       style: TextStyle(color: Colors.white),
       decoration: customInputDecoration(
-          hint: 'Enter your email', icon: Icon(Icons.mail)),
+        hint: 'Enter your email', icon: Icon(Icons.mail)),
       validator: (value) {
         if (value.isEmpty) {
           return 'Please enter your email';
         } else if (!EmailValidator.validate(value) && value.isNotEmpty) {
           return 'Please enter a valid email address';
-        }
+        } 
         return null;
       },
       onSaved: (value) => email = value.trim(),
@@ -84,28 +94,59 @@ class _SignInFormState extends State<SignInForm> {
         Text(
           "Forgot Password?",
           style: TextStyle(
-              fontSize: responsiveWidth(11.0),
-              fontWeight: FontWeight.w500,
-              color: Colors.cyanAccent),
+            fontSize: responsiveWidth(11.0),
+            fontWeight: FontWeight.w500,
+            color: Colors.cyanAccent),
         ),
       ]),
     );
   }
 
-  Widget signInButton(BuildContext context, GlobalKey<FormState> formKey) {
+  Widget signInButton(BuildContext context) { 
     return CoolButton(
       title: 'Sign in',
       textColor: Colors.white,
       filledColor: Colors.green,
-      onPressed: () {
+      onPressed: () async{
+        setState(() {
+          eMessage = "";
+        });
         if (formKey.currentState.validate()) {
           formKey.currentState.save();
-          context.read<AuthenticationService>().signIn(
-                email: emailController.text.trim(),
-                password: passwordController.text.trim(),
-              );
+          try {
+            await context.read<AuthenticationService>().signIn(
+              email: emailController.text.trim(),
+              password: passwordController.text.trim(),
+            );  
+          } catch (error) {
+            setState(() {
+              eMessage = error.message;
+            });    
+          }
         }
-      },
+      }
     );
   }
+
+  Widget displayErrorMessage() {
+    if (eMessage != null) {
+      return Text(
+        eMessage,
+        style: TextStyle(
+          color: Colors.redAccent,
+          fontSize: responsiveWidth(9.0),
+          fontWeight: FontWeight.w500,
+        )
+      );
+    } else {
+      return Text('');
+    }
+  }
 }
+
+
+
+
+
+
+

--- a/lib/widgets/sign_in_form.dart
+++ b/lib/widgets/sign_in_form.dart
@@ -9,7 +9,6 @@ import 'package:bikeapp/styles/cool_button.dart';
 import 'package:bikeapp/styles/custom_input_decoration.dart';
 
 class SignInForm extends StatefulWidget {
-
   @override
   _SignInFormState createState() => _SignInFormState();
 }
@@ -56,13 +55,13 @@ class _SignInFormState extends State<SignInForm> {
       keyboardType: TextInputType.emailAddress,
       style: TextStyle(color: Colors.white),
       decoration: customInputDecoration(
-        hint: 'Enter your email', icon: Icon(Icons.mail)),
+          hint: 'Enter your email', icon: Icon(Icons.mail)),
       validator: (value) {
         if (value.isEmpty) {
           return 'Please enter your email';
         } else if (!EmailValidator.validate(value) && value.isNotEmpty) {
           return 'Please enter a valid email address';
-        } 
+        }
         return null;
       },
       onSaved: (value) => email = value.trim(),
@@ -95,60 +94,50 @@ class _SignInFormState extends State<SignInForm> {
         Text(
           "Forgot Password?",
           style: TextStyle(
-            fontSize: responsiveWidth(11.0),
-            fontWeight: FontWeight.w500,
-            color: Colors.cyanAccent),
+              fontSize: responsiveWidth(11.0),
+              fontWeight: FontWeight.w500,
+              color: Colors.cyanAccent),
         ),
       ]),
     );
   }
 
-  Widget signInButton(BuildContext context) { 
+  Widget signInButton(BuildContext context) {
     return CoolButton(
-      title: 'Sign in',
-      textColor: Colors.white,
-      filledColor: Colors.green,
-      onPressed: () async{
-        setState(() {
-          eMessage = "";
-        });
-        if (formKey.currentState.validate()) {
-          formKey.currentState.save();
-          try {
-            await context.read<AuthenticationService>().signIn(
-              email: emailController.text.trim(),
-              password: passwordController.text.trim(),
-            );  
-          } catch (error) {
-            setState(() {
-              eMessage = error.message;
-            });    
+        title: 'Sign in',
+        textColor: Colors.white,
+        filledColor: Colors.green,
+        onPressed: () async {
+          setState(() {
+            eMessage = "";
+          });
+          if (formKey.currentState.validate()) {
+            formKey.currentState.save();
+            try {
+              await context.read<AuthenticationService>().signIn(
+                    email: emailController.text.trim(),
+                    password: passwordController.text.trim(),
+                  );
+              Navigator.of(context).pushNamed(MapScreen.routeName);
+            } catch (error) {
+              setState(() {
+                eMessage = error.message;
+              });
+            }
           }
-          Navigator.of(context).pushNamed(MapScreen.routeName);
-        }
-      }
-    );
+        });
   }
 
   Widget displayErrorMessage() {
     if (eMessage != null) {
-      return Text(
-        eMessage,
-        style: TextStyle(
-          color: Colors.redAccent,
-          fontSize: responsiveWidth(9.0),
-          fontWeight: FontWeight.w500,
-        )
-      );
+      return Text(eMessage,
+          style: TextStyle(
+            color: Colors.redAccent,
+            fontSize: responsiveWidth(9.0),
+            fontWeight: FontWeight.w500,
+          ));
     } else {
       return Text('');
     }
   }
 }
-
-
-
-
-
-
-

--- a/lib/widgets/sign_in_form.dart
+++ b/lib/widgets/sign_in_form.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bikeapp/models/responsive_size.dart';
 import 'package:bikeapp/screens/forgot_password.dart';
+import 'package:bikeapp/screens/map_screen.dart';
 import 'package:bikeapp/services/authentication_service.dart';
 import 'package:bikeapp/styles/cool_button.dart';
 import 'package:bikeapp/styles/custom_input_decoration.dart';
@@ -123,6 +124,7 @@ class _SignInFormState extends State<SignInForm> {
               eMessage = error.message;
             });    
           }
+          Navigator.of(context).pushNamed(MapScreen.routeName);
         }
       }
     );


### PR DESCRIPTION
- Implemented email/password error handling that can display error message on the login page 
- Fixed "request sent to email" popup for Forgot Password page to only come up if the email entered is valid.

Note: since catch block could not be called in VS Code - debug mode (Run > Start Debugging), run app from the VS Code terminal or console using “flutter run” in order to not experience Platform Exception error.
